### PR TITLE
Add auto-discovery of running Broadway pipelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,18 @@ live_dashboard "/dashboard",
   additional_pages: [
     broadway: {BroadwayDashboard, pipelines: [MyBroadway]}
   ]
-
 ```
 
 The `:pipelines` option accept pipeline names (the `:name` option of your Broadway).
+By ommiting the `:pipelines` option, `BroadwayDashboard` will try to autodiscover your pipelines.
+
+```elixir
+live_dashboard "/dashboard",
+  additional_pages: [
+    broadway: BroadwayDashboard
+  ]
+```
+
 Once configured, you will be able to access the `BroadwayDashboard` at `/dashboard/broadway`.
 
 ## Distribution

--- a/dev.exs
+++ b/dev.exs
@@ -130,7 +130,7 @@ defmodule DemoWeb.Router do
     live_dashboard("/dashboard",
       allow_destructive_actions: true,
       additional_pages: [
-        broadway: {BroadwayDashboard, pipelines: [Demo.Pipeline, BikeSharing]}
+        broadway: BroadwayDashboard
       ]
     )
   end

--- a/lib/broadway_dashboard.ex
+++ b/lib/broadway_dashboard.ex
@@ -74,10 +74,6 @@ defmodule BroadwayDashboard do
         pipeline = nav_pipeline && Enum.find(pipelines, fn name -> name == nav_pipeline end)
 
         cond do
-          nav_pipeline && is_nil(pipeline) ->
-            to = live_dashboard_path(socket, socket.assigns.page, nav: hd(pipelines))
-            {:ok, push_redirect(socket, to: to)}
-
           pipeline ->
             node = socket.assigns.page.node
 

--- a/test/broadway_dashboard_test.exs
+++ b/test/broadway_dashboard_test.exs
@@ -26,14 +26,6 @@ defmodule BroadwayDashboardTest do
                %{}
              )
 
-    assert {:disabled, "Broadway pipelines", ^link} =
-             BroadwayDashboard.menu_link(
-               %{pipelines: :auto_discover},
-               %{}
-             )
-
-    {:ok, _broadway} = start_supervised({Demo.Pipeline, [broadway_name: new_unique_name()]})
-
     assert {:ok, "Broadway pipelines"} =
              BroadwayDashboard.menu_link(
                %{pipelines: :auto_discover},
@@ -61,9 +53,11 @@ defmodule BroadwayDashboardTest do
   end
 
   describe "auto discovery" do
-    test "redirects to home if no pipeline is alive and auto discover is enabled" do
-      assert {:error, {:live_redirect, %{to: "/dashboard/home"}}} =
-               live(build_conn(), "/dashboard/broadway_auto_discovery")
+    test "renders error if no pipeline is alive and auto discover is enabled" do
+      {:ok, live, _} = live(build_conn(), "/dashboard/broadway_auto_discovery")
+
+      rendered = render(live)
+      assert rendered =~ "There is no pipeline running"
     end
 
     test "redirects to the first running pipeline if no pipeline is provided" do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -12,7 +12,7 @@ defmodule Demo.Pipeline do
 
   def start_link(opts) do
     Broadway.start_link(__MODULE__,
-      name: __MODULE__,
+      name: opts[:broadway_name] || __MODULE__,
       producer: [
         module: {Broadway.DummyProducer, opts},
         concurrency: 1
@@ -87,7 +87,8 @@ defmodule Phoenix.LiveDashboardTest.Router do
     live_dashboard("/dashboard",
       metrics: Phoenix.LiveDashboardTest.Telemetry,
       additional_pages: [
-        broadway: {BroadwayDashboard, pipelines: [Demo.Pipeline, MyDummy, MyDummyOutdated]}
+        broadway: {BroadwayDashboard, pipelines: [Demo.Pipeline, MyDummy, MyDummyOutdated]},
+        broadway_auto_discovery: BroadwayDashboard
       ]
     )
   end


### PR DESCRIPTION
This feature helps to avoid the need to setup the broadway pipelines in
the router. So this makes easier to integrate with a Phoenix
application.

The auto-discover mode will check for pipelines running in the current
(selected) node and display them in the tabs.