### PR TITLE
Use monotonic time for workload calculations

### DIFF
--- a/lib/broadway_dashboard.ex
+++ b/lib/broadway_dashboard.ex
@@ -44,6 +44,7 @@ defmodule BroadwayDashboard do
       pipeline_config == :auto_discover ->
         case check_broadway_version(node) do
           :ok ->
+            # TODO: fix case when pids are returned
             case :rpc.call(node, Broadway, :all_running, []) do
               [_ | _] = pipelines ->
                 {:ok, pipelines}


### PR DESCRIPTION
This is a fix in the workload/idle time calculation that was using the
"system time" from broadway telemetry measurements. The system time does
not work for us because it can "jump" backward in order to fix itself
with the OS and monotonic time.

See https://erlang.org/doc/man/erlang.html#system_time-0 for more
details.

Closes https://github.com/dashbitco/broadway_dashboard/issues/5