### PR TITLE
Fix the calc_workload function to avoid the error due to division by zero

### DIFF
--- a/lib/broadway_dashboard/telemetry.ex
+++ b/lib/broadway_dashboard/telemetry.ex
@@ -135,7 +135,11 @@ defmodule BroadwayDashboard.Telemetry do
   def handle_event(_, _, _, _), do: :ok
 
   defp calc_workload(start_time, last_end_time, duration) do
-    idle_time = start_time - last_end_time
-    round(duration / (idle_time + duration) * 100)
+    if duration > 0 do
+      idle_time = start_time - last_end_time
+      round(duration / (idle_time + duration) * 100)
+    else
+      0
+    end
   end
 end


### PR DESCRIPTION
This commit to fix the  calc_workload function to avoid the error due to division by zero.

The details discussion at #5 .

The cause is **Erlang monotonic time can return the same value many times** ! Then `idle_time` and `duration` might zero at unspecified point in time.

Following https://learnyousomeerlang.com/time:
> Erlang monotonic time. This is Erlang's view of the OS monotonic time if available, or the VM's own monotonic version of the system time if not available. This is the adjusted clock that is used for events, timers, and so on. Its stability makes it ideal to count a time interval. Do note that this time is monotonic, but not strictly monotonic, meaning that the clock can't go backwards, but it can return the same value many times!

> As mentioned earlier, the Erlang monotonic time is not strictly monotonic: it will possibly return the same number twice if it's called at the same time on two different cores, for example.

And under the hood of Erlang monotonic time are `clock_gettime` (Linux) , and `QueryPerformanceCounter` (QPC) (Windows) , the reference about them [here](https://aakinshin.net/posts/stopwatch/).

The code of commit is not beautiful but it can solve the problem :relaxed: