### PR TITLE
Fix crash when named using `:via`

### DIFF
--- a/lib/broadway_dashboard/metrics.ex
+++ b/lib/broadway_dashboard/metrics.ex
@@ -22,7 +22,7 @@ defmodule BroadwayDashboard.Metrics do
   end
 
   def server_name(pipeline) when is_atom(pipeline) do
-    :"Elixir.BroadwayDashboard.Metrics.#{inspect(pipeline)}"
+    :"broadway_dashboard_#{inspect(pipeline)}"
   end
 
   def server_name({:via, registry, term}) when is_atom(registry) do

--- a/lib/broadway_dashboard/metrics.ex
+++ b/lib/broadway_dashboard/metrics.ex
@@ -26,7 +26,7 @@ defmodule BroadwayDashboard.Metrics do
   end
 
   def server_name({:via, registry, term}) when is_atom(registry) do
-    :"Elixir.BroadwayDashboard.Metrics.#{inspect(registry)}.#{inspect(term)}"
+    :"broadway_dashboard_#{inspect(registry)}_#{inspect(term)}"
   end
 
   defp check_pipeline_running_at_node(pipeline, target_node) do

--- a/lib/broadway_dashboard/pipeline_graph.ex
+++ b/lib/broadway_dashboard/pipeline_graph.ex
@@ -57,16 +57,17 @@ defmodule BroadwayDashboard.PipelineGraph do
           |> Enum.sort_by(fn batcher -> batcher.batcher_key end)
           |> Enum.map(fn batcher ->
             label = to_string(batcher.batcher_key)
+            batcher_name = inspect(batcher.name)
 
             children_ids =
               previous_layer
               |> Enum.filter(fn batch_proc ->
-                String.starts_with?(to_string(batch_proc.id), to_string(batcher.name))
+                String.starts_with?(batch_proc.id, batcher_name)
               end)
               |> Enum.map(& &1.id)
 
             %{
-              id: batcher.batcher_name,
+              id: inspect(batcher.batcher_name),
               data: %{label: label, detail: batcher.batcher_workload},
               children: children_ids
             }
@@ -83,7 +84,7 @@ defmodule BroadwayDashboard.PipelineGraph do
     show_workload? = Keyword.get(opts, :show_workload?, true)
 
     for stage <- stage_details, i <- 0..(stage.concurrency - 1) do
-      name = :"#{stage.name}_#{i}"
+      name = "#{inspect(stage.name)}_#{i}"
 
       data =
         if show_workload? do

--- a/test/broadway_dashboard/metrics_test.exs
+++ b/test/broadway_dashboard/metrics_test.exs
@@ -4,29 +4,44 @@ defmodule BroadwayDashboard.MetricsTest do
   alias BroadwayDashboard.Metrics
   import BroadwayDashboard.BroadwaySupport
 
-  test "subscribe a process to a pipeline and ask it to refresh stats" do
-    broadway = start_linked_dummy_pipeline()
-    server_name = Metrics.server_name(broadway)
+  @registry_name BroadwayDashboardTestRegistry
 
-    me = self()
+  describe "subscribe a process to a pipeline and ask it to refresh stats" do
+    test "atom name" do
+      broadway = start_linked_dummy_pipeline()
+      subscribe_and_test(broadway)
+    end
 
-    proc =
-      spawn_link(fn ->
-        receive do
-          {:update_pipeline, payload} ->
-            send(me, {:refreshed, payload})
-        end
-      end)
+    test "via name" do
+      broadway = start_linked_dummy_pipeline({:via, Registry, {@registry_name, :metrics_test}})
+      subscribe_and_test(broadway)
+    end
 
-    {:ok, _} =
-      start_supervised({Metrics, [pipeline: broadway, name: server_name]}, id: server_name)
+    defp subscribe_and_test(broadway) do
+      server_name = Metrics.server_name(broadway)
 
-    assert {:ok, _payload} = Metrics.listen(node(), proc, broadway)
+      me = self()
 
-    send(server_name, :refresh)
+      proc =
+        spawn_link(fn ->
+          receive do
+            {:update_pipeline, payload} ->
+              send(me, {:refreshed, payload})
+          end
+        end)
 
-    assert_receive {:refreshed, payload}
-    assert payload.pipeline == broadway
+      {:ok, _} =
+        start_supervised({Metrics, [pipeline: broadway, name: server_name]}, id: server_name)
+
+      assert {:ok, _payload} = Metrics.listen(node(), proc, broadway)
+
+      send(server_name, :refresh)
+
+      assert_receive {:refreshed, payload}
+      assert payload.pipeline == broadway
+
+      :ok = Broadway.stop(broadway)
+    end
   end
 
   test "returns error if pipeline is not running" do
@@ -65,36 +80,49 @@ defmodule BroadwayDashboard.MetricsTest do
     assert counters != :sys.get_state(metrics).counters
   end
 
-  test "shutdown server when there is no listener" do
-    broadway = start_linked_dummy_pipeline()
-    server_name = Metrics.server_name(broadway)
+  describe "shutdown server when there is no listener" do
+    test "atom name" do
+      broadway = start_linked_dummy_pipeline()
+      listen_shutdown_test(broadway)
+    end
 
-    me = self()
+    test "via name" do
+      broadway = start_linked_dummy_pipeline({:via, Registry, {@registry_name, :metrics_test}})
+      listen_shutdown_test(broadway)
+    end
 
-    proc =
-      spawn_link(fn ->
-        receive do
-          {:update_pipeline, %{pipeline: ^broadway}} ->
-            send(me, :refreshed)
-            :ok
-        end
-      end)
+    defp listen_shutdown_test(broadway) do
+      server_name = Metrics.server_name(broadway)
 
-    {:ok, pid} =
-      start_supervised({Metrics, [pipeline: broadway, name: server_name, interval: 10]},
-        id: server_name
-      )
+      me = self()
 
-    {:ok, _payload} = Metrics.listen(node(), proc, broadway)
+      proc =
+        spawn_link(fn ->
+          receive do
+            {:update_pipeline, %{pipeline: ^broadway}} ->
+              send(me, :refreshed)
+              :ok
+          end
+        end)
 
-    assert_receive :refreshed
-    Process.sleep(10)
+      {:ok, pid} =
+        start_supervised({Metrics, [pipeline: broadway, name: server_name, interval: 10]},
+          id: server_name
+        )
 
-    refute Process.alive?(proc)
+      {:ok, _payload} = Metrics.listen(node(), proc, broadway)
 
-    # Wait for shutdown timer
-    Process.sleep(100)
+      assert_receive :refreshed
+      Process.sleep(10)
 
-    refute Process.alive?(pid)
+      refute Process.alive?(proc)
+
+      # Wait for shutdown timer
+      Process.sleep(100)
+
+      refute Process.alive?(pid)
+
+      :ok = Broadway.stop(broadway)
+    end
   end
 end


### PR DESCRIPTION
The PR #13 didn't test scene what named using `:via`, It will crash when in use.

I'm sorry about that, please help to review it again.