### PR TITLE
Improve Telemetry performance

### DIFF
--- a/lib/broadway_dashboard/telemetry.ex
+++ b/lib/broadway_dashboard/telemetry.ex
@@ -22,7 +22,7 @@ defmodule BroadwayDashboard.Telemetry do
       [:broadway, :batch_processor, :stop]
     ]
 
-    :telemetry.attach_many({__MODULE__, parent}, events, &handle_event/4, {pipeline, counters})
+    :telemetry.attach_many({__MODULE__, parent}, events, &__MODULE__.handle_event/4, {pipeline, counters})
   end
 
   def detach(parent) do


### PR DESCRIPTION
Addresses this warning regarding [`:telemetry.attach/4`](https://hexdocs.pm/telemetry/telemetry.html#attach/4):

```
Function passed as a handler with ID {BroadwayDashboard.Telemetry, #PID<0.1535.0>} is local function.
This mean that it is either anonymous function or capture of function without module specified. That may cause performance penalty when calling such handler. For more details see note in `telemetry:attach/4` documentation.

https://hexdocs.pm/telemetry/telemetry.html#attach-4
```
