### PR TITLE
Add support for Phoenix Live Dashboard 0.8.0

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -30,7 +30,7 @@ defmodule BroadwayDashboard.MixProject do
   defp deps do
     [
       {:broadway, "~> 1.0"},
-      {:phoenix_live_dashboard, "~> 0.5.1 or ~> 0.6.0 or ~> 0.7.0"},
+      {:phoenix_live_dashboard, "~> 0.5.1 or ~> 0.6.0 or ~> 0.7.0 or ~> 0.8.0"},
       {:phoenix_live_reload, "~> 1.2", only: :dev},
       {:plug_cowboy, "~> 2.0", only: :dev},
       {:jason, "~> 1.0", only: [:dev, :test, :docs]},


### PR DESCRIPTION
Similar to #22, this adds support for [0.8.0 of phoenix_live_dashboard](https://hex.pm/packages/phoenix_live_dashboard/0.8.0) released this week