### PR TITLE
Fixed the issue with multiple pipeline navigation

### DIFF
--- a/lib/broadway_dashboard.ex
+++ b/lib/broadway_dashboard.ex
@@ -145,9 +145,7 @@ defmodule BroadwayDashboard do
         for name <- assigns.pipelines do
           name = inspect(name)
 
-          {name,
-           "navigate",
-           name: name, render: fn -> render_pipeline_or_error(assigns) end}
+          {name, "navigate", name: name, render: fn -> render_pipeline_or_error(assigns) end}
         end
 
       nav_bar(items: items, page: assigns[:page])

--- a/lib/broadway_dashboard.ex
+++ b/lib/broadway_dashboard.ex
@@ -146,7 +146,8 @@ defmodule BroadwayDashboard do
           name = inspect(name)
 
           {name,
-           name: name, render: fn -> render_pipeline_or_error(assigns) end, method: :redirect}
+           "navigate",
+           name: name, render: fn -> render_pipeline_or_error(assigns) end}
         end
 
       nav_bar(items: items, page: assigns[:page])
@@ -158,7 +159,7 @@ defmodule BroadwayDashboard do
 
     ~H"""
     <.live_nav_bar id="broadway_navbar" page={@page}>
-      <:item name={name} :for={{name, item} <- @items}>
+      <:item name={name} method={method} :for={{name, method, item} <- @items}>
         <%= item[:render].() %>
       </:item>
     </.live_nav_bar>


### PR DESCRIPTION
When we have multiple broadway pipelines, the pipeline graph is not changed based on the selected pipeline menu. But works on reloading the page. The issue is with ```broadway_dashboard 0.4.0``` and ```phoenix_live_dashboard 0.8.0```

https://github.com/dashbitco/broadway_dashboard/assets/64002424/2b51a71f-c83a-4b2c-95ad-7c42bb08f582

But this works fine with ```broadway_dashboard 0.3.0``` and ```phoenix_live_dashboard 0.7.0```

This is because, in the latest version of broadway_dashboard, the method is not passed as expected with the ```phoenix_live_dashboard 0.8.0```. So by default, ```phoenix_live_dashboard``` considers this as patch navigation. But as we don't have any ```handle_params```, it is not navigating. 

Since ```broadway_dashboard 0.3.0``` passes **redirect** to **phoenix_live_dashboard**, it implements **push_redirect**(deprecated now) of live_view. Fixed this by passing **navigate**, as a separate attribute. 

This is my first open-source contribution. Correct me on my approach to this. 🙂