### PR TITLE
Changing <All Time> label and hint

### DIFF
--- a/lib/broadway_dashboard.ex
+++ b/lib/broadway_dashboard.ex
@@ -246,7 +246,7 @@ defmodule BroadwayDashboard do
       <:col>
         <.row>
           <:col>
-            <.card title="All time" hint="Messages since start." inner_title="successful"><%= @stats.successful %></.card>
+            <.card title="Successful" hint="Messages since the BroadwayDashboard page was first mounted." inner_title="successful"><%= @stats.successful %></.card>
           </:col>
           <:col>
             <.card inner_title="failed"><%= @stats.failed %></.card>

--- a/test/broadway_dashboard_test.exs
+++ b/test/broadway_dashboard_test.exs
@@ -87,7 +87,7 @@ defmodule BroadwayDashboardTest do
       rendered = render(live)
       assert rendered =~ "Updates automatically"
       assert rendered =~ "Throughput"
-      assert rendered =~ "All time"
+      assert rendered =~ "Successful"
     end
 
     test "auto discover is enabled when pipeline is registered using via" do
@@ -131,7 +131,7 @@ defmodule BroadwayDashboardTest do
       rendered = render(live)
       assert rendered =~ "Updates automatically"
       assert rendered =~ "Throughput"
-      assert rendered =~ "All time"
+      assert rendered =~ "Successful"
 
       assert rendered =~ "prod_0"
 


### PR DESCRIPTION
This pull request _tries_ to improve the label and hit on the dashboard page to make them more intuitive for users.

The original title “All time” and the hint “Messages since start” could be ambiguous for users trying to understand what the statistics represent. Changing the title to “Successful” and clarifying the hint helps users better understand the metrics being displayed, making the UI more user-friendly.
